### PR TITLE
Add CentOS/RHEL support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,6 +7,10 @@ galaxy_info:
   min_ansible_version: 1.9
   github_branch: master
   platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
     - name: Ubuntu
       versions:
         - trusty

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -1,2 +1,12 @@
 ---
 # tasks file for squid (CentOS specific)
+- name: Install squid packages
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - "{{ squid_packages }}"
+  tags:
+    - squid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,12 @@
 
 - name: Include release specific variables
   include_vars: "{{ ansible_distribution_release }}.yml"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - squid
 
 - include: CentOS.yml
-  when: ansible_distribution == "CentOS"
+  when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
   tags:
     - squid
 

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,2 +1,7 @@
 ---
 # vars file for squid (CentOS specific)
+squid_packages:
+  - squid
+squid_config_dir: /etc/squid
+squid_coredump_dir: /var/spool/squid
+squid_service_name: squid

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+CentOS.yml


### PR DESCRIPTION
Populated the vars and tasks files that were already in place; added
logic (and one symlink) to treat RHEL just like CentOS; skip inclusion
of codename-specific vars file on CentOS/RHEL.